### PR TITLE
Ignore empty directories during index builds

### DIFF
--- a/src/index-builder.test.ts
+++ b/src/index-builder.test.ts
@@ -129,6 +129,23 @@ test('buildManagedIndexBlock leaves empty directories blank', async () => {
   assert.equal(block, ['<!-- INDEX:START -->', '', '<!-- INDEX:END -->'].join('\n'));
 });
 
+test('buildManagedIndexBlock ignores empty child directories', async () => {
+  const rootDir = await mkdtemp(path.join(tmpdir(), 'mdorigin-index-empty-child-'));
+  await writeFile(path.join(rootDir, 'README.md'), '# Home\n', 'utf8');
+  await mkdir(path.join(rootDir, 'real-post'));
+  await writeFile(
+    path.join(rootDir, 'real-post', 'README.md'),
+    ['---', 'title: Real Post', 'type: post', '---', '', '# Real Post'].join('\n'),
+    'utf8',
+  );
+  await mkdir(path.join(rootDir, 'empty-dir'));
+
+  const block = await buildManagedIndexBlock(rootDir);
+
+  assert.match(block, /\[Real Post\]\(\.\/real-post\/\)/);
+  assert.doesNotMatch(block, /\[empty-dir\]\(\.\/empty-dir\/\)/);
+});
+
 test('buildDirectoryIndexes updates existing index files recursively', async () => {
   const rootDir = await mkdtemp(path.join(tmpdir(), 'mdorigin-index-build-'));
   await writeFile(path.join(rootDir, 'index.md'), '# Root\n', 'utf8');
@@ -157,6 +174,31 @@ test('buildDirectoryIndexes updates existing index files recursively', async () 
   const postsIndex = await readFile(path.join(rootDir, 'posts', 'index.md'), 'utf8');
   assert.match(postsIndex, /\[Hello\]\(\.\/hello\.md\)/);
   assert.doesNotMatch(postsIndex, /draft/i);
+});
+
+test('buildDirectoryIndexes skips empty directories and nested empty directories', async () => {
+  const rootDir = await mkdtemp(path.join(tmpdir(), 'mdorigin-index-skip-empty-'));
+  await writeFile(path.join(rootDir, 'README.md'), '# Root\n', 'utf8');
+  await mkdir(path.join(rootDir, 'real-section'));
+  await writeFile(path.join(rootDir, 'real-section', 'README.md'), '# Real Section\n', 'utf8');
+  await writeFile(
+    path.join(rootDir, 'real-section', 'hello.md'),
+    ['---', 'title: Hello', '---', '', '# Hello'].join('\n'),
+    'utf8',
+  );
+  await mkdir(path.join(rootDir, 'empty-dir'));
+  await mkdir(path.join(rootDir, 'empty-parent', 'empty-child'), { recursive: true });
+
+  const result = await buildDirectoryIndexes({ rootDir });
+  const rootIndex = await readFile(path.join(rootDir, 'README.md'), 'utf8');
+
+  assert.ok(!result.skippedDirectories.some((entry) => entry.endsWith('/empty-dir')));
+  assert.ok(!result.skippedDirectories.some((entry) => entry.endsWith('/empty-parent')));
+  assert.ok(!result.updatedFiles.some((entry) => entry.endsWith('/empty-dir/index.md')));
+  assert.ok(!result.updatedFiles.some((entry) => entry.endsWith('/empty-parent/index.md')));
+  assert.match(rootIndex, /\[Real Section\]\(\.\/real-section\/\)/);
+  assert.doesNotMatch(rootIndex, /\[empty-dir\]\(\.\/empty-dir\/\)/);
+  assert.doesNotMatch(rootIndex, /\[empty-parent\]\(\.\/empty-parent\/\)/);
 });
 
 test('buildDirectoryIndexes updates README.md when index.md is missing', async () => {

--- a/src/index-builder.ts
+++ b/src/index-builder.ts
@@ -147,6 +147,10 @@ export async function buildManagedIndexBlock(
     const fullPath = path.join(directoryPath, entry.name);
     const entryStats = await stat(fullPath);
     if (entryStats.isDirectory()) {
+      if (!(await hasMeaningfulDirectoryContent(fullPath))) {
+        continue;
+      }
+
       const resolvedEntry = await resolveDirectoryEntry(fullPath, entry.name);
       if (resolvedEntry.draft) {
         continue;
@@ -334,6 +338,10 @@ async function listDirectoriesRecursivelyInternal(
       continue;
     }
 
+    if (!(await hasMeaningfulDirectoryContent(childPath))) {
+      continue;
+    }
+
     directories.push(childPath);
 
     const childIndexPath = await resolveDirectoryIndexFile(childPath);
@@ -355,6 +363,55 @@ async function listDirectoriesRecursivelyInternal(
   }
 
   return directories;
+}
+
+async function hasMeaningfulDirectoryContent(
+  directoryPath: string,
+  visitedRealDirectories: Set<string> = new Set(),
+): Promise<boolean> {
+  const realDirectoryPath = await realpath(directoryPath);
+  if (visitedRealDirectories.has(realDirectoryPath)) {
+    return false;
+  }
+  visitedRealDirectories.add(realDirectoryPath);
+
+  const shape = await inspectDirectoryShape(directoryPath);
+  const indexPath = await resolveDirectoryIndexFile(directoryPath);
+  if (
+    indexPath !== null ||
+    shape.hasExtraMarkdownFiles ||
+    shape.hasAssetFiles ||
+    shape.hasSkillIndex
+  ) {
+    return true;
+  }
+
+  if (!shape.hasChildDirectories) {
+    return false;
+  }
+
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    if (shape.hasSkillIndex && isIgnoredSkillSupportDirectory(entry.name)) {
+      continue;
+    }
+
+    const childPath = path.join(directoryPath, entry.name);
+    const childStats = await stat(childPath);
+    if (!childStats.isDirectory()) {
+      continue;
+    }
+
+    if (await hasMeaningfulDirectoryContent(childPath, visitedRealDirectories)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 async function inspectDirectoryShape(directoryPath: string): Promise<{


### PR DESCRIPTION
## Summary
- ignore empty directories during `mdorigin build index`
- skip nested empty directory trees when walking content for managed index generation
- add regression tests for direct and nested empty directories

## Verification
- `npm run check`
- `npm test`

Closes #7.
