### PR TITLE
Fix catalog pagination for post directory bundles

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -146,15 +146,47 @@ export function extractManagedIndexEntries(markdown: string): ManagedIndexEntry[
 
     const rawHref = entryMatch[2];
     const href = rewriteMarkdownHref(rawHref);
+    const explicitKind = extractManagedIndexKind(lines.slice(1));
     entries.push({
-      kind: href.endsWith('/') ? 'directory' : 'article',
+      kind: explicitKind ?? (href.endsWith('/') ? 'directory' : 'article'),
       title: entryMatch[1],
       href,
-      detail: lines[1]?.trim() || undefined,
+      detail: extractManagedIndexDetail(lines.slice(1)),
     });
   }
 
   return entries;
+}
+
+function extractManagedIndexKind(
+  lines: readonly string[],
+): ManagedIndexEntry['kind'] | undefined {
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const match = trimmed.match(/^<!--\s*mdorigin:index\s+kind=(article|directory)\s*-->$/);
+    if (match) {
+      return match[1] as ManagedIndexEntry['kind'];
+    }
+  }
+
+  return undefined;
+}
+
+function extractManagedIndexDetail(lines: readonly string[]): string | undefined {
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '') {
+      continue;
+    }
+
+    if (/^<!--\s*mdorigin:index\s+kind=(article|directory)\s*-->$/.test(trimmed)) {
+      continue;
+    }
+
+    return trimmed;
+  }
+
+  return undefined;
 }
 
 function normalizeMeta(data: Record<string, unknown>): ParsedDocumentMeta {

--- a/src/core/request-handler.test.ts
+++ b/src/core/request-handler.test.ts
@@ -1112,3 +1112,73 @@ test('handleSiteRequest loads additional catalog articles in batches', async () 
   assert.equal(payload.hasMore, true);
   assert.equal(payload.nextOffset, 2);
 });
+
+test('handleSiteRequest paginates post directory bundles in catalog template', async () => {
+  const store = new MemoryContentStore([
+    {
+      path: 'README.md',
+      kind: 'text',
+      mediaType: 'text/markdown; charset=utf-8',
+      text: [
+        '---',
+        'title: Catalog Home',
+        '---',
+        '',
+        '# Catalog Home',
+        '',
+        '<!-- INDEX:START -->',
+        '',
+        '- [Post A](./post-a/)',
+        '  2026-03-28 · First bundled post.',
+        '  <!-- mdorigin:index kind=article -->',
+        '',
+        '- [Post B](./post-b/)',
+        '  2026-03-27 · Second bundled post.',
+        '  <!-- mdorigin:index kind=article -->',
+        '',
+        '<!-- INDEX:END -->',
+      ].join('\n'),
+    },
+  ]);
+
+  const response = await handleSiteRequest(store, '/', {
+    draftMode: 'include',
+    siteConfig: {
+      ...TEST_SITE_CONFIG,
+      template: 'catalog',
+      catalogInitialPostCount: 1,
+      catalogLoadMoreStep: 1,
+    },
+  });
+
+  assert.equal(response.status, 200);
+  const body = String(response.body);
+  assert.match(body, /Post A/);
+  assert.doesNotMatch(body, /Second bundled post\./);
+  assert.match(body, /data-catalog-load-more/);
+
+  const fragmentResponse = await handleSiteRequest(store, '/', {
+    draftMode: 'include',
+    siteConfig: {
+      ...TEST_SITE_CONFIG,
+      template: 'catalog',
+      catalogInitialPostCount: 1,
+      catalogLoadMoreStep: 1,
+    },
+    searchParams: new URLSearchParams({
+      'catalog-format': 'posts',
+      'catalog-offset': '1',
+      'catalog-limit': '1',
+    }),
+  });
+
+  assert.equal(fragmentResponse.status, 200);
+  const payload = JSON.parse(String(fragmentResponse.body)) as {
+    itemsHtml: string;
+    hasMore: boolean;
+    nextOffset: number;
+  };
+  assert.match(payload.itemsHtml, /Post B/);
+  assert.equal(payload.hasMore, false);
+  assert.equal(payload.nextOffset, 2);
+});

--- a/src/index-builder.ts
+++ b/src/index-builder.ts
@@ -270,6 +270,7 @@ function renderManagedIndexBlock(entries: ManagedIndexEntry[]): string {
       if (entry.detail) {
         lines.push(`  ${entry.detail}`);
       }
+      lines.push(`  <!-- mdorigin:index kind=${entry.kind} -->`);
       lines.push('');
     }
   }


### PR DESCRIPTION
## Summary
- preserve managed index entry kind metadata when serializing generated index blocks
- read explicit entry kind during catalog rendering, with legacy href-shape fallback
- add a regression test covering post directory bundles rendered through catalog pagination

## Testing
- npm test -- src/core/request-handler.test.ts
- npm test -- src/index-builder.test.ts
- npm run check

Closes #10