### PR TITLE
Improve directory route normalization and HTML 404s

### DIFF
--- a/docs/site/concepts/routing.md
+++ b/docs/site/concepts/routing.md
@@ -28,6 +28,8 @@ docs/site/
 
 If a directory has no `index.md`, the current runtime can still render a minimal fallback listing for browsing.
 
+Directory homepages are canonical with a trailing slash. When `/guides/` is a valid directory route, requesting `/guides` redirects to `/guides/`.
+
 The content tree may also include directory symlinks. `mdorigin` follows them in local preview and build-time processing, while keeping the published URL based on the visible path inside the content root.
 
 `/sitemap.xml` emits canonical HTML URLs, not `.md` source URLs. It requires `siteUrl` so the sitemap can use absolute locations.
@@ -41,6 +43,8 @@ Rendered HTML also exposes the source markdown path with:
 ```
 
 This is a lightweight interoperability hint for agents and tools that want to discover the raw markdown source from the human HTML page.
+
+For missing routes, `mdorigin` renders an HTML 404 page for human HTML requests, while markdown, asset, and API misses stay machine-friendly.
 
 When RSS is enabled, rendered HTML also exposes feed autodiscovery:
 

--- a/src/core/request-handler.test.ts
+++ b/src/core/request-handler.test.ts
@@ -388,6 +388,28 @@ test('handleSiteRequest filters drafts in exclude mode', async () => {
   assert.equal(excluded.status, 404);
 });
 
+test('handleSiteRequest renders html 404 pages but keeps markdown 404 plain text', async () => {
+  const htmlResponse = await handleSiteRequest(new MemoryContentStore([]), '/missing', {
+    draftMode: 'exclude',
+    siteConfig: TEST_SITE_CONFIG,
+  });
+
+  assert.equal(htmlResponse.status, 404);
+  assert.equal(htmlResponse.headers['content-type'], 'text/html; charset=utf-8');
+  assert.match(String(htmlResponse.body), /<h1>Not Found<\/h1>/);
+  assert.match(String(htmlResponse.body), /No page was published at <code>\/missing<\/code>/);
+  assert.match(String(htmlResponse.body), /<title>Not Found \| Test Site<\/title>/);
+
+  const markdownResponse = await handleSiteRequest(new MemoryContentStore([]), '/missing.md', {
+    draftMode: 'exclude',
+    siteConfig: TEST_SITE_CONFIG,
+  });
+
+  assert.equal(markdownResponse.status, 404);
+  assert.equal(markdownResponse.headers['content-type'], 'text/plain; charset=utf-8');
+  assert.equal(String(markdownResponse.body), 'Not Found');
+});
+
 test('handleSiteRequest renders sitemap.xml with canonical html urls', async () => {
   const store = new MemoryContentStore([
     {
@@ -854,6 +876,37 @@ test('handleSiteRequest renders SKILL.md as directory homepage fallback', async 
   });
   assert.equal(markdownResponse.status, 200);
   assert.match(String(markdownResponse.body), /^---/m);
+});
+
+test('handleSiteRequest redirects extensionless directory homepage requests to trailing slash', async () => {
+  const store = new MemoryContentStore([
+    {
+      path: 'guides/README.md',
+      kind: 'text',
+      mediaType: 'text/markdown; charset=utf-8',
+      text: ['---', 'title: Guides', '---', '', '# Guides'].join('\n'),
+    },
+    {
+      path: 'browse/intro.md',
+      kind: 'text',
+      mediaType: 'text/markdown; charset=utf-8',
+      text: '# Intro',
+    },
+  ]);
+
+  const directoryHomepage = await handleSiteRequest(store, '/guides', {
+    draftMode: 'include',
+    siteConfig: TEST_SITE_CONFIG,
+  });
+  assert.equal(directoryHomepage.status, 308);
+  assert.equal(directoryHomepage.headers.location, '/guides/');
+
+  const directoryListing = await handleSiteRequest(store, '/browse', {
+    draftMode: 'include',
+    siteConfig: TEST_SITE_CONFIG,
+  });
+  assert.equal(directoryListing.status, 308);
+  assert.equal(directoryListing.headers.location, '/browse/');
 });
 
 test('handleSiteRequest redirects alternate directory markdown filenames', async () => {

--- a/src/core/request-handler.test.ts
+++ b/src/core/request-handler.test.ts
@@ -389,24 +389,39 @@ test('handleSiteRequest filters drafts in exclude mode', async () => {
 });
 
 test('handleSiteRequest renders html 404 pages but keeps markdown 404 plain text', async () => {
-  const htmlResponse = await handleSiteRequest(new MemoryContentStore([]), '/missing', {
+  const store = new MemoryContentStore([]);
+
+  const htmlResponse = await handleSiteRequest(store, '/missing', {
     draftMode: 'exclude',
     siteConfig: TEST_SITE_CONFIG,
   });
 
   assert.equal(htmlResponse.status, 404);
   assert.equal(htmlResponse.headers['content-type'], 'text/html; charset=utf-8');
+  assert.equal(htmlResponse.headers.vary, 'Accept');
   assert.match(String(htmlResponse.body), /<h1>Not Found<\/h1>/);
   assert.match(String(htmlResponse.body), /No page was published at <code>\/missing<\/code>/);
   assert.match(String(htmlResponse.body), /<title>Not Found \| Test Site<\/title>/);
 
-  const markdownResponse = await handleSiteRequest(new MemoryContentStore([]), '/missing.md', {
+  const negotiatedMarkdownResponse = await handleSiteRequest(store, '/missing', {
+    draftMode: 'exclude',
+    siteConfig: TEST_SITE_CONFIG,
+    acceptHeader: 'text/markdown',
+  });
+
+  assert.equal(negotiatedMarkdownResponse.status, 404);
+  assert.equal(negotiatedMarkdownResponse.headers['content-type'], 'text/plain; charset=utf-8');
+  assert.equal(negotiatedMarkdownResponse.headers.vary, 'Accept');
+  assert.equal(String(negotiatedMarkdownResponse.body), 'Not Found');
+
+  const markdownResponse = await handleSiteRequest(store, '/missing.md', {
     draftMode: 'exclude',
     siteConfig: TEST_SITE_CONFIG,
   });
 
   assert.equal(markdownResponse.status, 404);
   assert.equal(markdownResponse.headers['content-type'], 'text/plain; charset=utf-8');
+  assert.equal(markdownResponse.headers.vary, undefined);
   assert.equal(String(markdownResponse.body), 'Not Found');
 });
 

--- a/src/core/request-handler.ts
+++ b/src/core/request-handler.ts
@@ -91,7 +91,7 @@ export async function handleSiteRequest(
       return aliasRedirect;
     }
 
-    return notFound();
+    return renderNotFoundForRequest(store, pathname, options);
   }
 
   const entry = await store.get(resolved.sourcePath);
@@ -120,6 +120,15 @@ export async function handleSiteRequest(
       return alternateMarkdownRedirect;
     }
 
+    const canonicalDirectoryRedirect = await tryRedirectCanonicalDirectoryPath(
+      store,
+      resolved,
+      options,
+    );
+    if (canonicalDirectoryRedirect !== null) {
+      return canonicalDirectoryRedirect;
+    }
+
     if (resolved.kind === 'html' && resolved.requestPath.endsWith('/')) {
       const directoryIndexResponse = await tryRenderAlternateDirectoryIndex(
         store,
@@ -138,7 +147,7 @@ export async function handleSiteRequest(
       );
     }
 
-    return notFound();
+    return renderNotFoundForResolvedRequest(store, resolved, options, negotiatedMarkdown);
   }
 
   if (resolved.kind === 'asset') {
@@ -146,13 +155,13 @@ export async function handleSiteRequest(
   }
 
   if (entry.kind !== 'text' || entry.text === undefined) {
-    return notFound();
+    return renderNotFoundForResolvedRequest(store, resolved, options, negotiatedMarkdown);
   }
 
   if (resolved.kind === 'markdown' || negotiatedMarkdown) {
     const parsed = await parseMarkdownDocument(resolved.sourcePath, entry.text);
     if (parsed.meta.draft === true && options.draftMode === 'exclude') {
-      return notFound();
+      return renderNotFoundForResolvedRequest(store, resolved, options, negotiatedMarkdown);
     }
 
     return {
@@ -169,7 +178,7 @@ export async function handleSiteRequest(
 
   const parsed = await parseMarkdownDocument(resolved.sourcePath, entry.text);
   if (parsed.meta.draft === true && options.draftMode === 'exclude') {
-    return notFound();
+    return renderNotFoundForResolvedRequest(store, resolved, options, negotiatedMarkdown);
   }
   const navigation = await resolveTopNav(store, options.siteConfig);
 
@@ -455,6 +464,66 @@ function notFound(): SiteResponse {
       'content-type': 'text/plain; charset=utf-8',
     },
     body: 'Not Found',
+  };
+}
+
+async function renderNotFoundForRequest(
+  store: ContentStore,
+  pathname: string,
+  options: HandleSiteRequestOptions,
+): Promise<SiteResponse> {
+  const resolved = resolveRequest(pathname);
+  return renderNotFoundForResolvedRequest(store, resolved, options, false);
+}
+
+async function renderNotFoundForResolvedRequest(
+  store: ContentStore,
+  resolved: ReturnType<typeof resolveRequest>,
+  options: HandleSiteRequestOptions,
+  negotiatedMarkdown: boolean,
+): Promise<SiteResponse> {
+  if (resolved.kind !== 'html' || negotiatedMarkdown) {
+    return notFound();
+  }
+
+  return renderHtmlNotFound(store, resolved.requestPath, options);
+}
+
+async function renderHtmlNotFound(
+  store: ContentStore,
+  requestPath: string,
+  options: HandleSiteRequestOptions,
+): Promise<SiteResponse> {
+  const navigation = await resolveTopNav(store, options.siteConfig);
+  const body = [
+    '<h1>Not Found</h1>',
+    `<p>No page was published at <code>${escapeHtml(requestPath)}</code>.</p>`,
+  ].join('');
+
+  return {
+    status: 404,
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+    },
+    body: renderDocument({
+      siteTitle: options.siteConfig.siteTitle,
+      siteDescription: options.siteConfig.siteDescription,
+      siteUrl: options.siteConfig.siteUrl,
+      favicon: options.siteConfig.favicon,
+      socialImage: options.siteConfig.socialImage,
+      logo: options.siteConfig.logo,
+      title: 'Not Found',
+      body,
+      showSummary: false,
+      showDate: false,
+      topNav: navigation.items,
+      footerNav: options.siteConfig.footerNav,
+      footerText: options.siteConfig.footerText,
+      socialLinks: options.siteConfig.socialLinks,
+      stylesheetContent: options.siteConfig.stylesheetContent,
+      rssFeedUrl: getRssFeedUrl(options.siteConfig.siteUrl, options.siteConfig),
+      searchEnabled: options.searchApi !== undefined,
+    }),
   };
 }
 
@@ -1015,6 +1084,46 @@ async function tryRedirectAlternateDirectoryMarkdown(
   }
 
   return null;
+}
+
+async function tryRedirectCanonicalDirectoryPath(
+  store: ContentStore,
+  resolved: ReturnType<typeof resolveRequest>,
+  options: HandleSiteRequestOptions,
+): Promise<SiteResponse | null> {
+  if (resolved.kind !== 'html' || resolved.requestPath.endsWith('/')) {
+    return null;
+  }
+
+  if (path.posix.extname(resolved.requestPath) !== '') {
+    return null;
+  }
+
+  const directoryPath = resolved.requestPath.slice(1);
+  if (directoryPath === '') {
+    return null;
+  }
+
+  const directoryEntries = await store.listDirectory(directoryPath);
+  if (directoryEntries === null) {
+    return null;
+  }
+
+  for (const candidatePath of getDirectoryIndexCandidates(directoryPath)) {
+    const entry = await store.get(candidatePath);
+    if (entry === null || entry.kind !== 'text' || entry.text === undefined) {
+      continue;
+    }
+
+    const parsed = await parseMarkdownDocument(candidatePath, entry.text);
+    if (parsed.meta.draft === true && options.draftMode === 'exclude') {
+      continue;
+    }
+
+    return redirect(`${resolved.requestPath}/`);
+  }
+
+  return redirect(`${resolved.requestPath}/`);
 }
 
 function getMarkdownRequestPathForContentPath(contentPath: string): string {

--- a/src/core/request-handler.ts
+++ b/src/core/request-handler.ts
@@ -123,7 +123,6 @@ export async function handleSiteRequest(
     const canonicalDirectoryRedirect = await tryRedirectCanonicalDirectoryPath(
       store,
       resolved,
-      options,
     );
     if (canonicalDirectoryRedirect !== null) {
       return canonicalDirectoryRedirect;
@@ -482,17 +481,19 @@ async function renderNotFoundForResolvedRequest(
   options: HandleSiteRequestOptions,
   negotiatedMarkdown: boolean,
 ): Promise<SiteResponse> {
+  const varyOnAccept = shouldVaryOnAccept(resolved);
   if (resolved.kind !== 'html' || negotiatedMarkdown) {
-    return notFound();
+    return withNotFoundVary(varyOnAccept);
   }
 
-  return renderHtmlNotFound(store, resolved.requestPath, options);
+  return renderHtmlNotFound(store, resolved.requestPath, options, varyOnAccept);
 }
 
 async function renderHtmlNotFound(
   store: ContentStore,
   requestPath: string,
   options: HandleSiteRequestOptions,
+  varyOnAccept: boolean,
 ): Promise<SiteResponse> {
   const navigation = await resolveTopNav(store, options.siteConfig);
   const body = [
@@ -502,9 +503,12 @@ async function renderHtmlNotFound(
 
   return {
     status: 404,
-    headers: {
-      'content-type': 'text/html; charset=utf-8',
-    },
+    headers: withVaryAcceptIfNeeded(
+      {
+        'content-type': 'text/html; charset=utf-8',
+      },
+      varyOnAccept,
+    ),
     body: renderDocument({
       siteTitle: options.siteConfig.siteTitle,
       siteDescription: options.siteConfig.siteDescription,
@@ -524,6 +528,22 @@ async function renderHtmlNotFound(
       rssFeedUrl: getRssFeedUrl(options.siteConfig.siteUrl, options.siteConfig),
       searchEnabled: options.searchApi !== undefined,
     }),
+  };
+}
+
+function withNotFoundVary(varyOnAccept: boolean): SiteResponse {
+  if (!varyOnAccept) {
+    return notFound();
+  }
+
+  return {
+    ...notFound(),
+    headers: withVaryAcceptIfNeeded(
+      {
+        'content-type': 'text/plain; charset=utf-8',
+      },
+      true,
+    ),
   };
 }
 
@@ -1089,7 +1109,6 @@ async function tryRedirectAlternateDirectoryMarkdown(
 async function tryRedirectCanonicalDirectoryPath(
   store: ContentStore,
   resolved: ReturnType<typeof resolveRequest>,
-  options: HandleSiteRequestOptions,
 ): Promise<SiteResponse | null> {
   if (resolved.kind !== 'html' || resolved.requestPath.endsWith('/')) {
     return null;
@@ -1107,20 +1126,6 @@ async function tryRedirectCanonicalDirectoryPath(
   const directoryEntries = await store.listDirectory(directoryPath);
   if (directoryEntries === null) {
     return null;
-  }
-
-  for (const candidatePath of getDirectoryIndexCandidates(directoryPath)) {
-    const entry = await store.get(candidatePath);
-    if (entry === null || entry.kind !== 'text' || entry.text === undefined) {
-      continue;
-    }
-
-    const parsed = await parseMarkdownDocument(candidatePath, entry.text);
-    if (parsed.meta.draft === true && options.draftMode === 'exclude') {
-      continue;
-    }
-
-    return redirect(`${resolved.requestPath}/`);
   }
 
   return redirect(`${resolved.requestPath}/`);


### PR DESCRIPTION
## Summary
- redirect extensionless directory homepage requests like `/guides` to the canonical `/guides/`
- render a built-in HTML 404 page for human HTML requests
- keep markdown, asset, and API misses machine-friendly

## Details
- `/foo` now returns `308` to `/foo/` when `foo/` is a valid directory route
- missing HTML page requests now return a rendered site-shell 404 document
- raw markdown 404s still return plain text `Not Found`
- routing docs updated to describe canonical trailing-slash directory routes and HTML 404 behavior

## Verification
- npm run check
- npm test

Closes #30